### PR TITLE
Bugfix: Replace the userbundle namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ class AppKernel extends Kernel
         $bundles = array(
             // ...
 
-            new Wearejust\UserBundle\WearejustRedirectBundle(),
+            new Wearejust\RedirectBundle\WearejustRedirectBundle(),
         );
 
         // ...


### PR DESCRIPTION
## Title
Change the 'UserBundle' refference to 'RedirectBundle'

## Changelog

### Fixed
- `UserBundle` refference in the readme with `RedirectBundle`